### PR TITLE
chore(deps): upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,26 +22,26 @@ ecbt-exchange = { path = "crates/ecbt-exchange", version = "0.0.0" }
 ecbt-binance = { path = "crates/ecbt-binance", version = "0.0.0" }
 ecbt-coinbase = { path = "crates/ecbt-coinbase", version = "0.0.0" }
 
-hex = "0.4.2"
-hmac = "0.8.1"
-sha2 = "0.9.1"
+hex = "0.4.3"
+hmac = "0.12.1"
+sha2 = "0.10.2"
 
-async-trait = "0.1"
-futures = "0.3.19"
-time = "0.3.9"
-rust_decimal = "1.23.1"
-url = "2.2.0"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-serde_urlencoded = "0.7.0"
-thiserror = "1"
-reqwest = { version = "0.11", features = ["blocking", "json"] }
-tokio = { version = "1", features = ["full"] }
-tokio-tungstenite = { version = "0.13", features = ["tls"] }
+async-trait = "0.1.57"
+futures = "0.3.21"
+time = "0.3.13"
+rust_decimal = "1.26.1"
+url = "2.2.2"
+serde = { version = "1.0.143", features = ["derive"] }
+serde_json = "1.0.83"
+serde_urlencoded = "0.7.1"
+thiserror = "1.0.32"
+reqwest = { version = "0.11.11", features = ["blocking", "json"] }
+tokio = { version = "1.20.1", features = ["full"] }
+tokio-tungstenite = { version = "0.17.2", features = ["native-tls"] }
 
-tracing = "0.1"
-tracing-appender = "0.2"
-tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
+tracing = "0.1.36"
+tracing-appender = "0.2.2"
+tracing-subscriber = { version = "0.3.15", features = ["json", "env-filter"] }
 
 [workspace]
 members = ["crates/*"]

--- a/crates/ecbt-exchange/src/info/market_pair_handle.rs
+++ b/crates/ecbt-exchange/src/info/market_pair_handle.rs
@@ -9,12 +9,12 @@ pub struct MarketPairHandle {
     pub inner: Arc<RwLock<MarketPairInfo>>,
 }
 
-impl<'a> MarketPairHandle {
+impl MarketPairHandle {
     pub fn new(inner: Arc<RwLock<MarketPairInfo>>) -> Self {
         Self { inner }
     }
 
-    pub fn read(&'a self) -> Result<MarketPairInfo> {
+    pub fn read(&self) -> Result<MarketPairInfo> {
         self.inner
             .read()
             .map(|guard| guard.clone())
@@ -22,7 +22,7 @@ impl<'a> MarketPairHandle {
     }
 }
 
-impl<'a> serde::Serialize for MarketPairHandle {
+impl serde::Serialize for MarketPairHandle {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "stable"
 components = ["rust-src"]  # rust-analyzer
-profile = "minimal"
+profile = "default"


### PR DESCRIPTION
> Due to compatibility reasons, this release does not yet remove the time 0.1 dependency, though chrono 0.4.20 does not depend on the vulnerable parts of the time 0.1.x versions. In a future 0.5 release, we will remove the time dependency.

Seems safe. It can be ignored!